### PR TITLE
Fix markdown table not rendering issue

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ export default defineConfig({
     shikiConfig: {
       theme: 'nord',
     },
+    remarkPlugins: ['remark-gfm', 'remark-smartypants'],
     rehypePlugins: [
       [
         'rehype-external-links',


### PR DESCRIPTION
- markdown table rendering is broken because of using `rehypePlugins` in astro config.
  This is due to the fact that enabling custom `remarkPlugins` or `rehypePlugins` will remove `remark-gfm`, `remark-smartypants` which are built-in plugins and we need to explicitly add these plugins. See notes section under this link - https://docs.astro.build/en/guides/markdown-content/#markdown-plugins
- added `remark-gfm` and `remark-smartypants` to fix this
- see screenshots comparing before and after of the markdown test page(http://localhost:3000/blog/markdown-test)

### Before

![before](https://user-images.githubusercontent.com/875450/186695549-0ce5fa0b-d6d5-4121-b912-5ab07ce70955.png)

### After

![after](https://user-images.githubusercontent.com/875450/186695590-03af0ee2-5355-45ee-bbf6-9a41f21dc55e.png)
)