### PR TITLE
Fixed [slug].astro not giving correct permalink

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -14,7 +14,7 @@ export async function getStaticPaths() {
 const { Content, frontmatter } = Astro.props.post;
 const { title, description, publishDate } = frontmatter;
 const { slug, readingTime } = getPostData(Astro.props.post);
-const permalink = `${Astro.site.href}${slug}`;
+const permalink = `${Astro.site.href}blog/${slug}`;
 ---
 
 <BaseLayout title={title} description={description} permalink={permalink} current="blog">


### PR DESCRIPTION
Currently the permalink being rendered is `<domain>/<post_slug>`, even though the url is `<domain>/blog/<post_slug>`. This commit should fix that issue.

Before commit:
![image](https://user-images.githubusercontent.com/22275786/202864382-98b303cf-a189-43a8-ba6d-d9f38ac033da.png)

After commit:
![image](https://user-images.githubusercontent.com/22275786/202864401-e781e355-aaf2-4789-b6cb-270a9b8b3fd9.png)
