### PR TITLE
Fix some mobile layout problems

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,6 +13,12 @@ const { current = '' } = Astro.props;
     padding: 2em;
     width: 100%;
   }
+
+  @media screen and (max-width: 520px) {
+    header {
+      padding: 2em 0;
+    }
+  }
 </style>
 
 <header>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -53,6 +53,13 @@ const { current = '' } = Astro.props;
   .theme-toggle-container {
     width: 75px;
   }
+
+  @media screen and (max-width: 520px) {
+    .theme-toggle-container {
+      margin-right: 1em;
+    }
+  }
+
 </style>
 
 <nav>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -196,10 +196,12 @@ table {
 th {
   border-bottom: 2px solid #cccccc;
   padding: 0.4em 0.8em;
+  word-break: break-word;
 }
 
 td {
   padding: 0.4em 0.8em;
+  word-break: break-word;
 }
 
 .container {


### PR DESCRIPTION
While working with this template, I noticed these two problems breaking the lay out on mobile slightly:

![table_before](https://github.com/user-attachments/assets/b5eb7b43-30a3-4ed7-a14a-14954f169052)

![nav_before](https://github.com/user-attachments/assets/ac4dca08-c722-4903-8c44-bc63171fe552)

## Proposed fixes

For tables, I chose to make words break if need be (which by itself wasn't enough to fully fix the layout breaking - it has to be both this and the navigation fix):

![table_after](https://github.com/user-attachments/assets/4d35ef33-278a-4339-b9fa-2a96cd29091f)

For the navigation, I removed the padding and instead added some margin inside of the container at the same breakpoint as the logo disappears:

![nav_after1](https://github.com/user-attachments/assets/a6e5ec5f-040e-4654-8e3e-10616efacab3)


Maybe you disagree with exactly how I solved these but I hope you'll agree that it should be fixed in some way. 😄